### PR TITLE
Move to thread-safe viper

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,10 @@ import (
 	"path"
 	"strings"
 
+	"github.com/layer5io/meshery-adapter-library/adapter"
+	"github.com/layer5io/meshery-adapter-library/common"
 	"github.com/layer5io/meshery-adapter-library/config"
+	"github.com/layer5io/meshery-adapter-library/status"
 	configprovider "github.com/layer5io/meshkit/config/provider"
 	"github.com/layer5io/meshkit/utils"
 	smp "github.com/layer5io/service-mesh-performance/spec"
@@ -21,10 +24,25 @@ const (
 var (
 	configRootPath = path.Join(utils.GetHome(), ".meshery")
 	KumaOperation  = strings.ToLower(smp.ServiceMesh_KUMA.Enum().String())
+
+	ServerConfig = map[string]string{
+		"name":     smp.ServiceMesh_KUMA.Enum().String(),
+		"type":     "adapter",
+		"port":     "10007",
+		"traceurl": status.None,
+	}
+
+	MeshSpec = map[string]string{
+		"name":    smp.ServiceMesh_KUMA.Enum().String(),
+		"status":  status.NotInstalled,
+		"version": status.None,
+	}
+
+	Operations = getOperations(common.Operations)
 )
 
 // New creates a new config instance
-func New(provider string) (config.Handler, error) {
+func New(provider string) (h config.Handler, err error) {
 	opts := configprovider.Options{
 		FilePath: configRootPath,
 		FileName: "kuma",
@@ -34,12 +52,35 @@ func New(provider string) (config.Handler, error) {
 	// Config provider
 	switch provider {
 	case configprovider.ViperKey:
-		return configprovider.NewViper(opts)
+		h, err = configprovider.NewViper(opts)
+		if err != nil {
+			return nil, err
+		}
 	case configprovider.InMemKey:
-		return configprovider.NewInMem(opts)
+		h, err = configprovider.NewInMem(opts)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, ErrEmptyConfig
 	}
 
-	return nil, config.ErrEmptyConfig
+	// Setup server config
+	if err := h.SetObject(adapter.ServerKey, ServerConfig); err != nil {
+		return nil, err
+	}
+
+	// Setup mesh config
+	if err := h.SetObject(adapter.MeshSpecKey, MeshSpec); err != nil {
+		return nil, err
+	}
+
+	// Setup Operations Config
+	if err := h.SetObject(adapter.OperationsKey, Operations); err != nil {
+		return nil, err
+	}
+
+	return h, nil
 }
 
 func NewKubeconfigBuilder(provider string) (config.Handler, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/layer5io/meshery-adapter-library/config"
-	configprovider "github.com/layer5io/meshery-adapter-library/config/provider"
+	configprovider "github.com/layer5io/meshkit/config/provider"
 	"github.com/layer5io/meshkit/utils"
 	smp "github.com/layer5io/service-mesh-performance/spec"
 )
@@ -26,10 +26,9 @@ var (
 // New creates a new config instance
 func New(provider string) (config.Handler, error) {
 	opts := configprovider.Options{
-		ServerConfig:   ServerDefaults,
-		MeshSpec:       MeshSpecDefaults,
-		ProviderConfig: ProviderConfigDefaults,
-		Operations:     OperationsDefaults,
+		FilePath: configRootPath,
+		FileName: "kuma",
+		FileType: "yaml",
 	}
 
 	// Config provider
@@ -45,10 +44,11 @@ func New(provider string) (config.Handler, error) {
 
 func NewKubeconfigBuilder(provider string) (config.Handler, error) {
 
-	opts := configprovider.Options{}
-
-	// Config environment
-	opts.ProviderConfig = KubeConfigDefaults
+	opts := configprovider.Options{
+		FilePath: configRootPath,
+		FileType: "yaml",
+		FileName: "kubeconfig",
+	}
 
 	// Config provider
 	switch provider {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -2,8 +2,8 @@ package config
 
 import (
 	"github.com/layer5io/meshery-adapter-library/common"
-	configprovider "github.com/layer5io/meshery-adapter-library/config/provider"
 	"github.com/layer5io/meshery-adapter-library/status"
+	configprovider "github.com/layer5io/meshkit/config/provider"
 	smp "github.com/layer5io/service-mesh-performance/spec"
 )
 

--- a/internal/config/error.go
+++ b/internal/config/error.go
@@ -21,6 +21,11 @@ import (
 const (
 	ErrGetLatestReleasesCode     = "1000"
 	ErrGetLatestReleaseNamesCode = "1001"
+	ErrEmptyConfigCode           = "replace_me"
+)
+
+var (
+	ErrEmptyConfig = errors.New(ErrEmptyConfigCode, errors.Alert, []string{"Config is empty"}, []string{}, []string{}, []string{})
 )
 
 // ErrGetLatestReleases is the error for fetching linkerd releases

--- a/kuma/kuma.go
+++ b/kuma/kuma.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/layer5io/meshery-adapter-library/adapter"
 	"github.com/layer5io/meshery-adapter-library/common"
-	adapterconfig "github.com/layer5io/meshery-adapter-library/config"
 	"github.com/layer5io/meshery-adapter-library/status"
 	internalconfig "github.com/layer5io/meshery-kuma/internal/config"
 	"github.com/layer5io/meshery-kuma/kuma/oam"
+	meshkitCfg "github.com/layer5io/meshkit/config"
 	"github.com/layer5io/meshkit/logger"
 	"github.com/layer5io/meshkit/models/oam/core/v1alpha1"
 )
@@ -26,7 +26,7 @@ type Kuma struct {
 }
 
 // New initializes kuma handler.
-func New(c adapterconfig.Handler, l logger.Handler, kc adapterconfig.Handler) adapter.Handler {
+func New(c meshkitCfg.Handler, l logger.Handler, kc meshkitCfg.Handler) adapter.Handler {
 	return &Kuma{
 		Adapter: adapter.Adapter{
 			Config:            c,

--- a/main.go
+++ b/main.go
@@ -13,10 +13,10 @@ import (
 	// "github.com/layer5io/meshkit/tracing"
 	"github.com/layer5io/meshery-adapter-library/adapter"
 	"github.com/layer5io/meshery-adapter-library/api/grpc"
-	configprovider "github.com/layer5io/meshery-adapter-library/config/provider"
 	"github.com/layer5io/meshery-kuma/internal/config"
 	"github.com/layer5io/meshery-kuma/kuma"
 	"github.com/layer5io/meshery-kuma/kuma/oam"
+	configprovider "github.com/layer5io/meshkit/config/provider"
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: sayantan1413 <sayantanbose2001@gmail.com>

**Description**

Operations are now thread safe. This has been done by replacing meshery-adapter-library config provider implementation with meshkit config provider implementation which share similar interfaces.

This PR fixes #191 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
