### PR TITLE
[Cl] Add step for generating short_sha for the filename

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -84,6 +84,8 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: data.json
+      - name: Add commit SHORT_SHA
+        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
       - name: echo results
         run: |
           pretty=$(jq . data.json)


### PR DESCRIPTION
Signed-off-by: Pranav Singh <pranavsingh02@hotmail.com>

**Description**

This PR adds a missing step in the `UpdateDocs` job for generating `SHORT_SHA` which is used in the filename for displaying the status of the adapter on the Meshery docs.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
