### PR TITLE
changed timestamp-format for e2e tests

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -99,7 +99,7 @@ jobs:
           filename=(`date +%m-%d-%Y-%H-%M-%m_${SHORT_SHA}`)
           echo $filename
           echo "---
-          timestamp: $(jq '.metadata.runon' data.json)
+          timestamp: $(jq '.metadata.runon| strptime("%a %b %e %X %Z %Y") | strftime("%Y-%m-%d %X %Z %a")' data.json)
           meshery-component: meshery-kuma
           meshery-component-version: $version
           meshery-server-version: $(jq '.metadata."meshery-server-version"' data.json)


### PR DESCRIPTION
Signed-off-by: asubedy <frexpe@pm.me>

**Description**
Timestamp format now : `YYYY-MM-D HH:MM:SS UTC <day>`
This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
