### PR TITLE
Update CI tests to newer core workflows

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -7,8 +7,7 @@ on:
     tags:
       - "v*"
     paths-ignore:
-      - 'docs/**'
-      - '.github/**'      
+      - 'docs/**'     
   pull_request:
     branches:
       - "*"
@@ -112,7 +111,7 @@ jobs:
           service-mesh: Kuma
           service-mesh-version: $(jq '.metadata.service_mesh_version' data.json)
           tests:
-            kuma-control-plane: $(jq '.resources_status."pod/kuma-control-plane"' data.json)
+            pod/kuma-control-plane: $(jq '.resources_status."pod/kuma-control-plane"' data.json)
           overall-status: $(jq '."overall-status"' data.json)
           ---" >  test.md
           mv test.md $filename.md

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -49,10 +49,11 @@ jobs:
 
   TestKuma:
     needs: SetPatternfile
-    uses: meshery/meshery/.github/workflows/testadapters.yaml@master
+    uses: meshery/meshery/.github/workflows/test_adapters.yaml@master
     with:
-      expected_pods: kuma-control-plane
-      expected_pods_namespaces: kuma
+      expected_resources: kuma-control-plane
+      expected_resources_types: pod
+      expected_resources_namespaces: kuma
       deployment_url: https://raw.githubusercontent.com/meshery/meshery/master/install/deployment_yamls/k8s/meshery-kuma-deployment.yaml
       service_url: https://raw.githubusercontent.com/meshery/meshery/master/install/deployment_yamls/k8s/meshery-kuma-service.yaml
       adapter_name: kuma
@@ -111,7 +112,7 @@ jobs:
           service-mesh: Kuma
           service-mesh-version: $(jq '.metadata.service_mesh_version' data.json)
           tests:
-            kuma-control-plane: $(jq '.pods_status."kuma-control-plane"' data.json)
+            kuma-control-plane: $(jq '.resources_status."pod/kuma-control-plane"' data.json)
           overall-status: $(jq '."overall-status"' data.json)
           ---" >  test.md
           mv test.md $filename.md


### PR DESCRIPTION
Signed-off-by: Tathagata Paul <tathagatapaul7@gmail.com>

**Description**
Ports the Kuma CI tests to the new core e2e workflow

This PR is a part of https://github.com/meshery/meshery/issues/5529

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
