### PR TITLE
Refine summary messages for Kuma service mesh operations

### DIFF
--- a/kuma/kuma.go
+++ b/kuma/kuma.go
@@ -66,7 +66,7 @@ func (kuma *Kuma) ApplyOperation(ctx context.Context, opReq adapter.OperationReq
 				hh.streamErr(summary, ee, err)
 				return
 			}
-			ee.Summary = fmt.Sprintf("Kuma service mesh %s successfully", stat)
+			ee.Summary = fmt.Sprintf("Kuma service mesh %s.", stat)
 			ee.Details = fmt.Sprintf("The Kuma service mesh is now %s.", stat)
 			hh.StreamInfo(ee)
 		}(kuma, e)
@@ -79,7 +79,7 @@ func (kuma *Kuma) ApplyOperation(ctx context.Context, opReq adapter.OperationReq
 				hh.streamErr(summary, ee, err)
 				return
 			}
-			ee.Summary = fmt.Sprintf("%s application %s successfully", appName, stat)
+			ee.Summary = fmt.Sprintf("%s application %s", appName, stat)
 			ee.Details = fmt.Sprintf("The %s application is now %s.", appName, stat)
 			hh.StreamInfo(ee)
 		}(kuma, e)
@@ -102,7 +102,7 @@ func (kuma *Kuma) ApplyOperation(ctx context.Context, opReq adapter.OperationReq
 				hh.streamErr(summary, ee, err)
 				return
 			}
-			ee.Summary = "SMI conformance passed successfully"
+			ee.Summary = "SMI conformance passed"
 			ee.Details = ""
 			hh.StreamInfo(ee)
 		}(kuma, e)
@@ -114,7 +114,7 @@ func (kuma *Kuma) ApplyOperation(ctx context.Context, opReq adapter.OperationReq
 				hh.streamErr(summary, ee, err)
 				return
 			}
-			ee.Summary = fmt.Sprintf("Manifest %s successfully", status.Deployed)
+			ee.Summary = fmt.Sprintf("Manifest status is: %s", status.Deployed)
 			ee.Details = ""
 			hh.StreamInfo(ee)
 		}(kuma, e)

--- a/kuma/oam.go
+++ b/kuma/oam.go
@@ -43,7 +43,7 @@ func (kuma *Kuma) HandleComponents(comps []v1alpha1.Component, isDel bool, kubec
 				errs = append(errs, err)
 				continue
 			}
-			ee.Summary = fmt.Sprintf("%s %s successfully", strings.TrimSuffix(comp.Spec.Type, ".KUMA"), stat2)
+			ee.Summary = fmt.Sprintf("%s %s.", strings.TrimSuffix(comp.Spec.Type, ".KUMA"), stat2)
 			ee.Details = fmt.Sprintf("The %s is now %s.", strings.TrimSuffix(comp.Spec.Type, ".KUMA"), stat2)
 			kuma.StreamInfo(ee)
 			msgs = append(msgs, msg)
@@ -56,7 +56,7 @@ func (kuma *Kuma) HandleComponents(comps []v1alpha1.Component, isDel bool, kubec
 			errs = append(errs, err)
 			continue
 		}
-		ee.Summary = fmt.Sprintf("%s %s %s successfully", comp.Name, comp.Spec.Type, stat2)
+		ee.Summary = fmt.Sprintf("%s %s %s.", comp.Name, comp.Spec.Type, stat2)
 		ee.Details = fmt.Sprintf("The %s %s is now %s.", comp.Name, comp.Spec.Type, stat2)
 		kuma.StreamInfo(ee)
 		msgs = append(msgs, msg)

--- a/main.go
+++ b/main.go
@@ -178,5 +178,5 @@ func registerWorkloads(port string, log logger.Handler) {
 		log.Info(err.Error())
 		return
 	}
-	log.Info("Successfully registered latest service mesh components with Meshery Server at ", mesheryServerAddress())
+	log.Info("Registered latest service mesh components with Meshery Server at ", mesheryServerAddress())
 }


### PR DESCRIPTION
eliminating the usage of `successfully` word as it seems off for logging

fixes #445 