### PR TITLE
[meshery-kuma] ci: globally disable ST1005 staticcheck lint rule

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,6 @@
 linters-settings:
+  staticcheck:
+    checks: ["all", "-ST1005"]
   depguard:
     list-type: blacklist
     packages:


### PR DESCRIPTION
### **Description**

This PR adds the `staticcheck` configuration to `.golangci.yml` to globally and permanently disable the **ST1005** (lowercase error strings) lint rule for the Kuma adapter.

Fixes meshery/meshery#16867

### **Notes for Reviewers**

- Updated `.golangci.yml` to suppress ST1005 globally.
- Verified that `staticcheck` is already in the `enable` list.
- Standardizing lint rules across all adapters.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.