### PR TITLE
chore: bump Go version to 1.26.4

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23
+        go-version-file: go.mod
     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go build .
   docker:
     name: Docker build and push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23 
+          go-version-file: go.mod
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
       - run: GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go install github.com/kisielk/errcheck@latest; /home/runner/go/bin/errcheck -tags draft ./...
   error_code_check:
     name: Error code utility check
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.23
+          go-version-file: go.mod
       - run: |
             errWillHave="level=error"
             GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go install github.com/layer5io/meshkit/cmd/errorutil;
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
       - uses: dominikh/staticcheck-action@v1
         with:
           install-go: false
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
       - run: GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go vet -tags draft ./...
   sec_check:
     name: Security check
@@ -127,7 +127,7 @@ jobs:
      - name: Setup Go
        uses: actions/setup-go@v5
        with:
-        go-version: 1.23
+        go-version-file: go.mod
      - name: Create cluster using KinD
        uses: engineerd/setup-kind@v0.5.0
        with:

--- a/.github/workflows/error-ref-publisher.yml
+++ b/.github/workflows/error-ref-publisher.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
 
       - name: Run utility
         run: |

--- a/.github/workflows/update-oam-defs.yml
+++ b/.github/workflows/update-oam-defs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
       - name: Run adapter to create components
         run: |
           touch log.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.26.4 as builder
 
 ARG VERSION
 ARG GIT_COMMITSHA

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/layer5io/meshery-kuma
 
-go 1.23
+go 1.26.4
 
 replace github.com/kudobuilder/kuttl => github.com/layer5io/kuttl v0.4.1-0.20200723152044-916f10574334
 


### PR DESCRIPTION
**Description**

Upgrade Go version from 1.23 to 1.26.4.

**Fixes:** meshery/meshery#19875

**Verified with:**

- `go build ./...`
- `go test ./...`
- `go vet ./...`

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 